### PR TITLE
Update to pre-release buildah image references

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -80,7 +80,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:876f30a03605b242f2ae46381160cd3270e035bb91327cf9f4ded7c5fdf8ec7e
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:36d811c6439e497a73cd4797542c5afb50f3f496891188348000b5536d1bed0d
         - name: kind
           value: task
       runAfter:
@@ -124,7 +124,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:876f30a03605b242f2ae46381160cd3270e035bb91327cf9f4ded7c5fdf8ec7e
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:36d811c6439e497a73cd4797542c5afb50f3f496891188348000b5536d1bed0d
         - name: kind
           value: task
       runAfter:
@@ -168,7 +168,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:876f30a03605b242f2ae46381160cd3270e035bb91327cf9f4ded7c5fdf8ec7e
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:36d811c6439e497a73cd4797542c5afb50f3f496891188348000b5536d1bed0d
         - name: kind
           value: task
       runAfter:
@@ -212,7 +212,7 @@ spec:
         - name: name
           value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:876f30a03605b242f2ae46381160cd3270e035bb91327cf9f4ded7c5fdf8ec7e
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.1@sha256:36d811c6439e497a73cd4797542c5afb50f3f496891188348000b5536d1bed0d
         - name: kind
           value: task
       runAfter:
@@ -287,7 +287,7 @@ spec:
         - name: name
           value: source-build-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:3c1ddfff7799dc8224f8e1c3a0989b9e803ca4ac276c8bc80ad736b23cbd73de
+          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:5dbbbf00f813b41c101dfae310c3eaee7654ce114fbcdbbf094092317eeb83ea
         - name: kind
           value: task
       when:

--- a/Containerfile.task-image
+++ b/Containerfile.task-image
@@ -1,5 +1,5 @@
 # Instead of producing an image that runs buildah, create an image which allows buildah to be called
-FROM quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+FROM quay.io/konflux-ci/buildah:latest@sha256:7cd298d576ebb1e1805ef2c72daa37864791a9dc3b1de7641414d6ef8815e0fe
 USER 0
 WORKDIR /
 ENTRYPOINT ["/bin/bash"]

--- a/Containerfile.task-image
+++ b/Containerfile.task-image
@@ -1,5 +1,7 @@
 # Instead of producing an image that runs buildah, create an image which allows buildah to be called
-FROM quay.io/konflux-ci/buildah:latest@sha256:7cd298d576ebb1e1805ef2c72daa37864791a9dc3b1de7641414d6ef8815e0fe
+# This will eventually reference a released image in quay.io/konflux-ci/buildah:latest but we want to
+#   pin to the latest pre-release version of buildah
+FROM quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah@sha256:7cd298d576ebb1e1805ef2c72daa37864791a9dc3b1de7641414d6ef8815e0fe
 USER 0
 WORKDIR /
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
We shouldn't pin to released images as we need to be able to pull them to build (which may happen before the release pipeline completes)