### PR TITLE
Simplify building of buildah

### DIFF
--- a/Containerfile.buildah
+++ b/Containerfile.buildah
@@ -17,19 +17,22 @@ COPY buildah/ .
 
 RUN make buildah
 
-# Rebase on ubi9
-FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:081c96d1b1c7cd1855722d01f1ca53360510443737b1eb33284c6c4c330e537c
+# # Rebase on ubi9
+# FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:081c96d1b1c7cd1855722d01f1ca53360510443737b1eb33284c6c4c330e537c
 
+# COPY --from=builder /go/src/containers/buildah/bin/buildah /usr/bin/buildah
+
+# WORKDIR /workdir
+
+# RUN \
+#   groupadd -g 1000 buildah; \
+#   useradd -u 1000 -g buildah -s /bin/sh -d /home/buildah buildah
+
+# RUN chown -R buildah:buildah /workdir
+
+# USER buildah
+
+# ENTRYPOINT ["/usr/bin/buildah"]
+# Rebase on ubi9/buildah to insert our newer binary
+FROM registry.access.redhat.com/ubi9/buildah:latest
 COPY --from=builder /go/src/containers/buildah/bin/buildah /usr/bin/buildah
-
-WORKDIR /workdir
-
-RUN \
-  groupadd -g 1000 buildah; \
-  useradd -u 1000 -g buildah -s /bin/sh -d /home/buildah buildah
-
-RUN chown -R buildah:buildah /workdir
-
-USER buildah
-
-ENTRYPOINT ["/usr/bin/buildah"]


### PR DESCRIPTION
The two-step process of building buildah is over complicating matters.

We could create a container that just runs the buildah binary or we can just create a container with the binary and run buildah from it.

This latter approach looks like what we did with the previous buildah image which did not have its source tracked and it also is what is done in the registry.access.redhat.com/ubi9/buildah:latest image.

Since this approach is what I was doing with the second step, let's just remove the first step and copy the newer binary directly into a buildah image as that is the part that we want to update.