### PR TITLE
Update sast-snyk-check

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -390,10 +390,14 @@ spec:
         values:
         - 'false'
       runAfter:
-      - clone-repository
+      - build-image-index
       params:
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: clamav-scan
       taskRef:
         resolver: bundles


### PR DESCRIPTION
Replaces https://github.com/konflux-ci/buildah-container/pull/33 as that PR had improper references due to the fact that no build-container task exists. Instead, the image index task needs to be used.