### PR TITLE
Remove entitlement sharing from host

### DIFF
--- a/.tekton/buildah-pull-request.yaml
+++ b/.tekton/buildah-pull-request.yaml
@@ -28,7 +28,7 @@ spec:
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after
-    value: 5d
+    value: 1w
   - name: output-image
     value: quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah:on-pr-{{revision}}
   - name: path-context

--- a/.tekton/buildah-pull-request.yaml
+++ b/.tekton/buildah-pull-request.yaml
@@ -45,6 +45,8 @@ spec:
     value: "true"
   pipelineRef:
     name: build-pipeline
+  timeouts:
+    pipeline: "2h0m0s"
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/buildah-push.yaml
+++ b/.tekton/buildah-push.yaml
@@ -42,6 +42,8 @@ spec:
     value: "true"
   pipelineRef:
     name: build-pipeline
+  timeouts:
+    pipeline: "2h0m0s"
   workspaces:
   - name: git-auth
     secret:

--- a/Containerfile.image_build
+++ b/Containerfile.image_build
@@ -68,8 +68,11 @@ COPY --from=builder /go/src/containers/buildah/bin/buildah /usr/bin/buildah
 
 ADD image_build/buildah/containers.conf /etc/containers/
 
+# The source image_build containerfile passes secrets from the host to the internal container.
+# We will not do that in Konflux as it results in inconsistent container builds due to
+# the fact that the hosts are not entitled for any subscriptions.
 # Setup internal Buildah to pass secrets/subscriptions down from host to internal container
-RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
+# RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
 
 # Copy & modify the defaults to provide reference if runtime changes needed.
 # Changes here are required for running with fuse-overlay storage inside container.

--- a/README.md
+++ b/README.md
@@ -10,5 +10,3 @@ cd buildah
 git checkout main && git pull
 cd ..
 ```
-
-If you want to have a `Verified` commit, it appears that you need to include some other content with the submodule update.


### PR DESCRIPTION
Results for being able to install packages were inconsistent when the entitlements were shared from the host to the container build. Since the containers running on unentitled hosts, the sharing resulted in errors to find appropriate packages. Users should be able to easily install RPMs that are in UBI repos.

Resolves: KFLUXBUGS-1506