### PR TITLE
Update the task image for use on remote and local builds

### DIFF
--- a/Containerfile.task
+++ b/Containerfile.task
@@ -1,0 +1,10 @@
+# Konflux does not only support running builds in containers locally but also supports running builds
+# in remote VMs with the multi-platform controller. In order to simplify the specification of build
+# targets, however, we are adding support for the multi-platform controller to also be able to build
+# in-cluseter with the tasks focused on building remotely. Therefore, we need to maintain a buildah image
+# for our tasks that has more than _just_ buildah in it. We also need to add the required functionality
+# for the remote builds.
+FROM quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah@sha256:582df00cc6f76ef7e23111f2f83f5f56327cd4134f0518b93b9148c17fdd8ed1
+RUN microdnf install -y rsync openssh-clients kubernetes-client && \
+    microdnf -y clean all && \
+    rm -rf /var/cache /var/log/dnf* /var/log/yum.*

--- a/Containerfile.task-image
+++ b/Containerfile.task-image
@@ -1,6 +1,0 @@
-# Instead of producing an image that only runs buildah, create an image which allows buildah to be called
-# This will eventually reference a released image in quay.io/konflux-ci/buildah:latest but we want to
-#   pin to the latest pre-release version of buildah
-FROM quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah@sha256:9b803e7a8c545064a4b21da32a2825192f70431e7b6c6cf84717671ebf619f8f as buildah-image
-FROM registry.access.redhat.com/ubi9/buildah:latest
-COPY --from=buildah-image /usr/bin/buildah /usr/bin/buildah


### PR DESCRIPTION
As part of https://github.com/konflux-ci/build-definitions/pull/1216, we need to have a version of buildah that can work for both local and remote builds. This ports over the changes needed for the remote runner while still being able to use the latest buildah images.

The prior containerfile was https://github.com/konflux-ci/build-tasks-dockerfiles/blob/main/multi-platform-runner/Dockerfile