### PR TITLE
chore: Add podman to the image

### DIFF
--- a/Containerfile.task
+++ b/Containerfile.task
@@ -5,6 +5,6 @@
 # for our tasks that has more than _just_ buildah in it. We also need to add the required functionality
 # for the remote builds.
 FROM quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
-RUN microdnf install -y rsync openssh-clients kubernetes-client && \
+RUN microdnf install -y rsync openssh-clients kubernetes-client podman && \
     microdnf -y clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*


### PR DESCRIPTION
Will be replacing `quay.io/redhat-appstudio/multi-platform-runner` (image used in rpm-ostree and build-vm-image tasks in build-definitions repo) with `quay.io/konflux-ci/buildah-task `
podman is missing in this image `quay.io/konflux-ci/buildah-task `, this PR adds it

This is part of the story: https://issues.redhat.com/browse/STONEBLD-2716 