### PR TITLE
Add renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+    "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
+    "packageRules": [
+      {
+        "matchDatasources": ["docker"],
+        "enabled": false,
+        "matchPackageNames": ["/^registry.fedoraproject.org/"]
+      }
+    ]
+}


### PR DESCRIPTION
Renovate was updating the Fedora floating tags to undesired versions. Removing those from matches.