### PR TITLE
Remove sbom-json-check task from build pipeline

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -418,28 +418,6 @@ spec:
         value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
       - name: image-url
         value: "$(tasks.build-image-index.results.IMAGE_URL)"
-    - name: sbom-json-check
-      taskRef:
-        resolver: bundles
-        params:
-        - name: name
-          value: sbom-json-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sbom-json-check:0.2@sha256:d4eee0cfef2069273752f6d27088b147ae6eac5f5db45e481efb4ae1a07883f6
-        - name: kind
-          value: task
-      when:
-      - input: "$(params.skip-checks)"
-        operator: in
-        values:
-        - 'false'
-      runAfter:
-      - build-image-index
-      params:
-      - name: IMAGE_URL
-        value: "$(tasks.build-image-index.results.IMAGE_URL)"
-      - name: IMAGE_DIGEST
-        value: "$(tasks.build-image-index.results.IMAGE_DIGEST)"
     - name: apply-tags
       params:
       - name: IMAGE
@@ -514,19 +492,19 @@ spec:
       default: ""
     - name: enable-amd64-build
       type: string
-      description: Enable amd64 builds 
+      description: Enable amd64 builds
       default: "true"
     - name: enable-arm64-build
       type: string
-      description: Enable arm64 builds 
+      description: Enable arm64 builds
       default: "false"
     - name: enable-ppc64le-build
       type: string
-      description: Enable ppc64le builds 
+      description: Enable ppc64le builds
       default: "false"
     - name: enable-s390x-build
       type: string
-      description: Enable s390x builds 
+      description: Enable s390x builds
       default: "false"
     - name: amd64-platform
       type: string


### PR DESCRIPTION
Remove sbom-json-check task from build pipeline because it's deprecated and it's presence will fail EC soon.