### PR TITLE
Update renovate config for ignoring fedora images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
     "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
-    "packageRules": [
-      {
-        "matchDatasources": ["docker"],
-        "enabled": false,
-        "matchPackageNames": ["^registry.fedoraproject.org/"]
-      }
+    "ignoreDeps": [
+        "egistry.fedoraproject.org/"
     ]
 }


### PR DESCRIPTION
Since the fedoraproject does not use static tags, we are changing the Renovate config to just ignore these dependencies all together.