### PR TITLE
install iproute instead of route

### DIFF
--- a/Containerfile.task
+++ b/Containerfile.task
@@ -19,7 +19,7 @@ RUN go build -o dockerfile-json
 
 FROM quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah@sha256:10d3a9eedfadf4908d1432a658bde1803e2d406cda4b73115699f5359321da36
 
-ARG INSTALL_RPMS="rsync openssh-clients kubernetes-client jq route"
+ARG INSTALL_RPMS="rsync openssh-clients kubernetes-client jq iproute"
 RUN microdnf install -y $INSTALL_RPMS && \
     microdnf -y clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*


### PR DESCRIPTION
The wrong package was added in PR (https://github.com/konflux-ci/buildah-container/pull/90) - 'route' was added but we really need 'iproute'. Fixing that.