### PR TITLE
replace dockerfile-json fork with upstream

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/containers/image_build.git
 [submodule "dockerfile-json"]
 	path = dockerfile-json
-	url = https://github.com/konflux-ci/dockerfile-json.git
+	url = https://github.com/keilerkonzept/dockerfile-json.git


### PR DESCRIPTION
- konflux-ci fork of the dockerfile-json repository was created with own fix
- The fix was merged into upstream and the fork is no longer needed
- Change the dockerfile-json submodule to follow upstream