### PR TITLE
Revert "replace dockerfile-json fork with upstream"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/containers/image_build.git
 [submodule "dockerfile-json"]
 	path = dockerfile-json
-	url = https://github.com/keilerkonzept/dockerfile-json.git
+	url = https://github.com/konflux-ci/dockerfile-json.git

--- a/.tekton/buildah-pull-request.yaml
+++ b/.tekton/buildah-pull-request.yaml
@@ -12,7 +12,6 @@ metadata:
       ".tekton/buildah-pull-request.yaml".pathChanged() ||
       ".tekton/buildah-push.yaml".pathChanged() ||
       "buildah".pathChanged() ||
-      "dockerfile-json".pathChanged() ||
       "image_build".pathChanged() ||
       "Containerfile.image_build".pathChanged())
   creationTimestamp: null

--- a/.tekton/buildah-push.yaml
+++ b/.tekton/buildah-push.yaml
@@ -11,7 +11,6 @@ metadata:
       ".tekton/buildah-pull-request.yaml".pathChanged() ||
       ".tekton/buildah-push.yaml".pathChanged() ||
       "buildah".pathChanged() ||
-      "dockerfile-json".pathChanged() ||
       "image_build".pathChanged() ||
       "Containerfile.image_build".pathChanged())
   creationTimestamp: null


### PR DESCRIPTION
```
[1/2] STEP 8/8: RUN go build -o dockerfile-json
go: go.mod requires go >= 1.23 (running go 1.22.7; GOTOOLCHAIN=local)
subprocess exited with status 1
subprocess exited with status 1
Error: building at STEP "RUN go build -o dockerfile-json": exit status 1
```
in `buildah-task` PipelineRuns

Reverts konflux-ci/buildah-container#99