### PR TITLE
revert dockerfile-json to using go1.21

### DIFF
--- a/.tekton/buildah-pull-request.yaml
+++ b/.tekton/buildah-pull-request.yaml
@@ -12,7 +12,6 @@ metadata:
       ".tekton/buildah-pull-request.yaml".pathChanged() ||
       ".tekton/buildah-push.yaml".pathChanged() ||
       "buildah".pathChanged() ||
-      "dockerfile-json".pathChanged() ||
       "image_build".pathChanged() ||
       "Containerfile.image_build".pathChanged())
   creationTimestamp: null

--- a/.tekton/buildah-push.yaml
+++ b/.tekton/buildah-push.yaml
@@ -11,7 +11,6 @@ metadata:
       ".tekton/buildah-pull-request.yaml".pathChanged() ||
       ".tekton/buildah-push.yaml".pathChanged() ||
       "buildah".pathChanged() ||
-      "dockerfile-json".pathChanged() ||
       "image_build".pathChanged() ||
       "Containerfile.image_build".pathChanged())
   creationTimestamp: null

--- a/.tekton/buildah-task-pull-request.yaml
+++ b/.tekton/buildah-task-pull-request.yaml
@@ -11,6 +11,7 @@ metadata:
       (".tekton/build-pipeline.yaml".pathChanged() ||
       ".tekton/buildah-task-pull-request.yaml".pathChanged() ||
       ".tekton/buildah-task-push.yaml".pathChanged() ||
+      "dockerfile-json".pathChanged() ||
       "Containerfile.task".pathChanged())
   creationTimestamp: null
   labels:

--- a/.tekton/buildah-task-push.yaml
+++ b/.tekton/buildah-task-push.yaml
@@ -10,6 +10,7 @@ metadata:
       (".tekton/build-pipeline.yaml".pathChanged() ||
       ".tekton/buildah-task-pull-request.yaml".pathChanged() ||
       ".tekton/buildah-task-push.yaml".pathChanged() ||
+      "dockerfile-json".pathChanged() ||
       "Containerfile.task".pathChanged())
   creationTimestamp: null
   labels:


### PR DESCRIPTION
- dockerfile-json bumped go1.21 to go1.23
- go1.22.7 is used in pipelines resulting in failing builds