### PR TITLE
feat(KONFLUX-7125): Change buildah task to use overlay2 storage driver

### DIFF
--- a/Containerfile.image_build
+++ b/Containerfile.image_build
@@ -79,9 +79,8 @@ ADD image_build/buildah/containers.conf /etc/containers/
 
 # Copy & modify the defaults to provide reference if runtime changes needed.
 # Changes here are required for running with fuse-overlay storage inside container.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-        -e '/additionalimage.*/a "/var/lib/shared",' \
-        -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,fsync=0"|g' \
+RUN sed -e '/additionalimage.*/a "/var/lib/shared",' \
+        -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,metacopy=on"|g' \
         /usr/share/containers/storage.conf \
         > /etc/containers/storage.conf && \
     chmod 644 /etc/containers/storage.conf && \
@@ -107,8 +106,7 @@ RUN useradd build && \
 # Copy & modify the config for the `build` user and remove the global
 # `runroot` and `graphroot` which current `build` user cannot access,
 # in such case storage will choose a runroot in `/var/tmp`.
-RUN sed -e 's|^#mount_program|mount_program|g' \
-        -e 's|^graphroot|#graphroot|g' \
+RUN sed -e 's|^graphroot|#graphroot|g' \
         -e 's|^runroot|#runroot|g' \
         /etc/containers/storage.conf \
         > /home/build/.config/containers/storage.conf && \

--- a/Containerfile.image_build
+++ b/Containerfile.image_build
@@ -78,8 +78,15 @@ ADD image_build/buildah/containers.conf /etc/containers/
 # RUN printf '/run/secrets/etc-pki-entitlement:/run/secrets/etc-pki-entitlement\n/run/secrets/rhsm:/run/secrets/rhsm\n' > /etc/containers/mounts.conf
 
 # Copy & modify the defaults to provide reference if runtime changes needed.
-# Changes here are required for running with fuse-overlay storage inside container.
-RUN sed -e '/additionalimage.*/a "/var/lib/shared",' \
+
+# Commenting out mount_program = "/usr/bin/fuse-overlayfs" forces Buildah to use the kernel's native
+# overlayfs (overlay2) driver instead of fuse-overlayfs.
+
+# Update mountopt to be "nodev,metacopy=on". "metacopy=on" enables metadata-only copy-up, which is
+# a feature of newer kernels that improves performance of overlayfs by avoiding full file copy when
+# only metadata changes.
+RUN sed -e 's|^mount_program|#mount_program|g' \
+        -e '/additionalimage.*/a "/var/lib/shared",' \
         -e 's|^mountopt[[:space:]]*=.*$|mountopt = "nodev,metacopy=on"|g' \
         /usr/share/containers/storage.conf \
         > /etc/containers/storage.conf && \
@@ -106,7 +113,8 @@ RUN useradd build && \
 # Copy & modify the config for the `build` user and remove the global
 # `runroot` and `graphroot` which current `build` user cannot access,
 # in such case storage will choose a runroot in `/var/tmp`.
-RUN sed -e 's|^graphroot|#graphroot|g' \
+RUN sed -e 's|^mount_program|#mount_program|g' \
+        -e 's|^graphroot|#graphroot|g' \
         -e 's|^runroot|#runroot|g' \
         /etc/containers/storage.conf \
         > /home/build/.config/containers/storage.conf && \


### PR DESCRIPTION
Update configuration file to make buildah runs with overlay2 storage driver by default. 

This update would allow the buildah-remote-oci-ta is able to run with the overlay2 storage driver. See the PR[1].

[1] https://github.com/konflux-ci/build-definitions/pull/2074