### PR TITLE
fix(KONFLUX-7507): Add image content manifest script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+*   @konflux-ci/build-maintainers

--- a/.github/workflows/inject-icm-test.yaml
+++ b/.github/workflows/inject-icm-test.yaml
@@ -1,0 +1,25 @@
+name: Test icm-injection-scripts
+
+on:
+  pull_request:
+    branches:
+    - main
+    paths:
+    - .github/workflows/inject-icm-test.yaml
+    - /scripts/icm-injection-scripts/**
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Run test for cyclonedx
+      run: |
+        TEST_SBOM_FORMAT=cyclonedx ./scripts/icm-injection-scripts/test-inject-icm.sh
+
+    - name: Run test for spdx
+      run: |
+        TEST_SBOM_FORMAT=spdx ./scripts/icm-injection-scripts/test-inject-icm.sh

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*   @konflux-ci/build-maintainers
+*   @konflux-ci/build-maintainers @arewm

--- a/Containerfile.task
+++ b/Containerfile.task
@@ -17,6 +17,8 @@ WORKDIR /app
 COPY dockerfile-json .
 RUN go build -o dockerfile-json
 
+COPY scripts/icm-injection-scripts/inject-icm.sh /scripts
+
 FROM quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah@sha256:391ce6bd8652a81d1237d4aec46acabec0a6b61f9a7ea94a16ffa1a40d759378
 
 ARG INSTALL_RPMS="rsync openssh-clients kubernetes-client jq iproute subscription-manager"

--- a/scripts/icm-injection-scripts/inject-icm.sh
+++ b/scripts/icm-injection-scripts/inject-icm.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Inject an ICM (image content manifest) file with content sets for backwards compatibility
+#
+# https://github.com/containerbuildsystem/atomic-reactor/blob/master/atomic_reactor/schemas/content_manifest.json
+#
+# This is not a file we want to inject always into the future, but older Red
+# Hat build systems injected a file like this and some third-party scanners
+# depend on it in order to map rpms found in each layer to CPE ids, to match
+# them with vulnerability data. In the future, those scanners should port to
+# using the dnf db and/or SBOMs to make that same match. Consider this
+# deprecated.
+#
+# This is only possible for images built hermetically with prefetch
+
+set -euo pipefail
+
+IMAGE="${1}"
+SQUASH="${SQUASH:-false}"
+
+icm_filename="content-sets.json"
+# Note this used to be /root/buildinfo/content_manifests but is now /usr/share/buildinfo for compatibility
+# with bootc/ostree systems. Ref https://issues.redhat.com/browse/KONFLUX-6844
+location="/usr/share/buildinfo/${icm_filename}"
+
+if [ ! -f "./sbom-cachi2.json" ]; then
+  echo "Could not find sbom-cachi2.json. No content_sets found for ICM"
+  exit 0
+fi
+
+echo "Extracting annotations to copy to the modified image"
+base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
+base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
+
+echo "Creating container from $IMAGE"
+CONTAINER=$(buildah from --pull-never $IMAGE)
+trap 'buildah rm "$CONTAINER"' EXIT
+
+echo "Preparing construction of $location for container $CONTAINER to be committed back as $IMAGE (squash: $SQUASH)"
+cat >content-sets.json <<EOF
+{
+    "metadata": {
+	"icm_version": 1,
+	"icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+	"image_layer_index": 0
+    },
+    "from_dnf_hint": true,
+    "content_sets": []
+}
+
+EOF
+
+while IFS='' read -r content_set;
+do
+  if [ "${content_set}" != "" ]; then
+    jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json > content-sets.json.tmp
+    mv content-sets.json.tmp content-sets.json
+  fi
+done <<< "$(
+    jq -r '
+        if .bomFormat == "CycloneDX" then
+            .components[].purl
+        else
+            .packages[].externalRefs[]? | select(.referenceType == "purl") | .referenceLocator
+        end' sbom-cachi2.json |
+    grep -o -P '(?<=repository_id=).*(?=(&|$))' |
+    sort -u
+)"
+
+echo "Constructed the following:"
+cat content-sets.json
+
+echo "Writing that to $location"
+buildah copy "$CONTAINER" content-sets.json /usr/share/buildinfo/
+buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$CONTAINER"
+
+BUILDAH_ARGS=()
+if [ "${SQUASH}" == "true" ]; then
+  BUILDAH_ARGS+=("--squash")
+fi
+
+echo "Committing that back to $IMAGE"
+buildah commit "${BUILDAH_ARGS[@]}" "$CONTAINER" "$IMAGE"

--- a/scripts/icm-injection-scripts/test-data/Containerfile
+++ b/scripts/icm-injection-scripts/test-data/Containerfile
@@ -1,0 +1,3 @@
+ARG FORMAT
+FROM registry.fedoraproject.org/fedora-minimal:41
+LABEL sbom-format=$FORMAT

--- a/scripts/icm-injection-scripts/test-data/sbom-cachi2-cyclonedx.json
+++ b/scripts/icm-injection-scripts/test-data/sbom-cachi2-cyclonedx.json
@@ -1,0 +1,175 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/fedora/glibc-common@2.39-6.fc40?arch=x86_64&checksum=sha256:45fe79ffea9358fc7a4f233e2358b08678bdec476680d0655063b4a4058e8789&repository_id=releases",
+      "version": "2.39",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "glibc-common",
+      "purl": "pkg:rpm/fedora/glibc-common@2.39-6.fc40?arch=x86_64&repository_id=releases",
+      "version": "2.39",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+          "name": "cachi2:missing_hash:in_file",
+          "value": "another-project/rpms.lock.yaml"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/fedora/glibc-minimal-langpack@2.38-7.fc39?arch=x86_64&checksum=sha256:6f9b45618d3b46fbbfb44407e05dd7054f3bd6a4df4f7291b576858b88deadc5&repository_id=releases",
+      "version": "2.38",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "purl": "pkg:rpm/fedora/glibc-minimal-langpack@2.39-6.fc40?arch=x86_64&checksum=sha256:9982f68ddcc3e972a2f3f220f29d56b0e9dde0e409bdecfe0bc559fe39013dde&repository_id=releases",
+      "version": "2.39",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "gzip",
+      "purl": "pkg:rpm/fedora/gzip@1.13-1.fc40?arch=x86_64&checksum=sha256:6dcc2f8885135fc873c8ab94a6c7df05883060c5b25287956bebb3aa15a84e71&repository_id=releases",
+      "version": "1.13",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "apr-util-bdb",
+      "purl": "pkg:rpm/redhat/apr-util-bdb@1.6.1-9.el8?arch=x86_64&checksum=sha256:106ed56188f62702d967d3148b05ef2f0e43fceee7b2bc3d44dd53be20a300b5&repository_id=ubi-8-appstream-rpms",
+      "version": "1.6.1",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "apr-util-openssl",
+      "purl": "pkg:rpm/redhat/apr-util-openssl@1.6.1-9.el8?arch=x86_64&checksum=sha256:bb636fb6d64af9e9a9b3f432dd587d60946c987b31758c59a20a0d7872099c14&repository_id=ubi-8-appstream-rpms",
+      "version": "1.6.1",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "apr-util",
+      "purl": "pkg:rpm/redhat/apr-util@1.6.1-9.el8?arch=src&checksum=sha256:3a7dec001ee63a28de3f1609a4b3da03ec9c8eda3f6802fe491cf456be267e82&repository_id=ubi-8-appstream-source",
+      "version": "1.6.1",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "apr-util",
+      "purl": "pkg:rpm/redhat/apr-util@1.6.1-9.el8?arch=x86_64&checksum=sha256:153b5f51d3e71191b5ccd483298911aeb9a0794cc9d8f13ae22cac8c5b3643e3&repository_id=ubi-8-appstream-rpms",
+      "version": "1.6.1",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "apr",
+      "purl": "pkg:rpm/redhat/apr@1.6.3-12.el8?arch=src&checksum=sha256:31c1ce68fb74c6426ac6270f0f255199daffc9000897343efcdff0a41e914f9d&repository_id=ubi-8-appstream-source",
+      "version": "1.6.3",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "apr",
+      "purl": "pkg:rpm/redhat/apr@1.6.3-12.el8?arch=x86_64&checksum=sha256:4be7cfbb58aeec0db66ac9d2e996de662499bac99a2788f934f87d6998ba073e&repository_id=ubi-8-appstream-rpms",
+      "version": "1.6.3",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "httpd-tools",
+      "purl": "pkg:rpm/redhat/httpd-tools@2.4.37-65.module%2Bel8.10.0%2B22196%2Bd82931da.2?arch=x86_64&checksum=sha256:2b650ff7cfb275f157f849f7dc7883c4f7b9bf9f8d89e10a1406c4d7802b3387&repository_id=ubi-8-appstream-rpms",
+      "version": "2.4.37",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "httpd",
+      "purl": "pkg:rpm/redhat/httpd@2.4.37-65.module%2Bel8.10.0%2B22196%2Bd82931da.2?arch=src&checksum=sha256:bc1c91f3fce3452aa7dba9810592cf2a40957ef5d3b2d23a96c1853365425c50&repository_id=ubi-8-appstream-source",
+      "version": "2.4.37",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "red hat",
+        "name": "cachi2"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/scripts/icm-injection-scripts/test-data/sbom-cachi2-spdx.json
+++ b/scripts/icm-injection-scripts/test-data/sbom-cachi2-spdx.json
@@ -1,0 +1,390 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "dataLicense": "CC0-1.0",
+  "name": "",
+  "documentNamespace": "NOASSERTION",
+  "creationInfo": {
+    "creators": [
+      "Tool: cachi2",
+      "Organization: red hat"
+    ],
+    "created": "2025-01-13T09:51:43Z"
+  },
+  "packages": [
+    {
+      "SPDXID": "SPDXRef-DocumentRoot-File-",
+      "name": "",
+      "versionInfo": "",
+      "externalRefs": [],
+      "annotations": [],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-apr-1.6.3-1e2e21f55c49e50881b467a875d1bbfede39dfe02594958a02463f5dbdb6e05e",
+      "name": "apr",
+      "versionInfo": "1.6.3",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/apr@1.6.3-12.el8?arch=src&checksum=sha256:31c1ce68fb74c6426ac6270f0f255199daffc9000897343efcdff0a41e914f9d&repository_id=ubi-8-appstream-source",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-apr-1.6.3-f45835cfe760749f68574114b52bbfd25036acdd30ce3553c30a4708056dbbf2",
+      "name": "apr",
+      "versionInfo": "1.6.3",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/apr@1.6.3-12.el8?arch=x86_64&checksum=sha256:4be7cfbb58aeec0db66ac9d2e996de662499bac99a2788f934f87d6998ba073e&repository_id=ubi-8-appstream-rpms",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-apr-util-1.6.1-54dac25e7fe18cff27ca527e7bd31f72d11596f313c8997cc7f5eda57396d4e6",
+      "name": "apr-util",
+      "versionInfo": "1.6.1",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/apr-util@1.6.1-9.el8?arch=src&checksum=sha256:3a7dec001ee63a28de3f1609a4b3da03ec9c8eda3f6802fe491cf456be267e82&repository_id=ubi-8-appstream-source",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-apr-util-1.6.1-158322a7f051adb5cbf6a7e1d5a06c716bbf00d2a11211a8410023c2fc7cf2d0",
+      "name": "apr-util",
+      "versionInfo": "1.6.1",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/apr-util@1.6.1-9.el8?arch=x86_64&checksum=sha256:153b5f51d3e71191b5ccd483298911aeb9a0794cc9d8f13ae22cac8c5b3643e3&repository_id=ubi-8-appstream-rpms",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-apr-util-bdb-1.6.1-80a350715c5d5bce1ed3adcb29bdac2f69b9e432b8e148486428fb5a1dbed133",
+      "name": "apr-util-bdb",
+      "versionInfo": "1.6.1",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/apr-util-bdb@1.6.1-9.el8?arch=x86_64&checksum=sha256:106ed56188f62702d967d3148b05ef2f0e43fceee7b2bc3d44dd53be20a300b5&repository_id=ubi-8-appstream-rpms",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-apr-util-openssl-1.6.1-51b9c3b95c53f3b666732fc45eb7e926976375b5e848a0ff53c05e765441a319",
+      "name": "apr-util-openssl",
+      "versionInfo": "1.6.1",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/apr-util-openssl@1.6.1-9.el8?arch=x86_64&checksum=sha256:bb636fb6d64af9e9a9b3f432dd587d60946c987b31758c59a20a0d7872099c14&repository_id=ubi-8-appstream-rpms",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-glibc-common-2.39-d94aa3f6228e20ca5fc645a33339470bb020492c164adf965d69388fc85a6e92",
+      "name": "glibc-common",
+      "versionInfo": "2.39",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/fedora/glibc-common@2.39-6.fc40?arch=x86_64&checksum=sha256:45fe79ffea9358fc7a4f233e2358b08678bdec476680d0655063b4a4058e8789&repository_id=releases",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-glibc-common-2.39-fab6e099abf5033d3104beadf5ff1bf60708378f3a52f6e3d92ecdf708d3329a",
+      "name": "glibc-common",
+      "versionInfo": "2.39",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/fedora/glibc-common@2.39-6.fc40?arch=x86_64&repository_id=releases",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        },
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:missing_hash:in_file\", \"value\": \"another-project/rpms.lock.yaml\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-glibc-minimal-langpack-2.38-3a5546b79055579930b001b0ff7d3aedf0cdce68ab86148169fa8d6f004ad7eb",
+      "name": "glibc-minimal-langpack",
+      "versionInfo": "2.38",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/fedora/glibc-minimal-langpack@2.38-7.fc39?arch=x86_64&checksum=sha256:6f9b45618d3b46fbbfb44407e05dd7054f3bd6a4df4f7291b576858b88deadc5&repository_id=releases",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-glibc-minimal-langpack-2.39-e7fa29dee8fa39c1c698993c821122e82be41477d32b1e1927cc27005f92ec3f",
+      "name": "glibc-minimal-langpack",
+      "versionInfo": "2.39",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/fedora/glibc-minimal-langpack@2.39-6.fc40?arch=x86_64&checksum=sha256:9982f68ddcc3e972a2f3f220f29d56b0e9dde0e409bdecfe0bc559fe39013dde&repository_id=releases",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-gzip-1.13-9d35dafbe4dd02490cb1d8927e51b0e34f7da5d593a4f30570c1f0a435a0d2db",
+      "name": "gzip",
+      "versionInfo": "1.13",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/fedora/gzip@1.13-1.fc40?arch=x86_64&checksum=sha256:6dcc2f8885135fc873c8ab94a6c7df05883060c5b25287956bebb3aa15a84e71&repository_id=releases",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-httpd-2.4.37-4b5382e33a9ca75388ecf09694c83f42996d010c4ffb2bb68315fd79bf814406",
+      "name": "httpd",
+      "versionInfo": "2.4.37",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/httpd@2.4.37-65.module%2Bel8.10.0%2B22196%2Bd82931da.2?arch=src&checksum=sha256:bc1c91f3fce3452aa7dba9810592cf2a40957ef5d3b2d23a96c1853365425c50&repository_id=ubi-8-appstream-source",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    },
+    {
+      "SPDXID": "SPDXRef-Package-httpd-tools-2.4.37-9635cd40e1b282eefd2d4dd96daf7b7d924041d526f0c7267f129a524a4894ac",
+      "name": "httpd-tools",
+      "versionInfo": "2.4.37",
+      "externalRefs": [
+        {
+          "referenceLocator": "pkg:rpm/redhat/httpd-tools@2.4.37-65.module%2Bel8.10.0%2B22196%2Bd82931da.2?arch=x86_64&checksum=sha256:2b650ff7cfb275f157f849f7dc7883c4f7b9bf9f8d89e10a1406c4d7802b3387&repository_id=ubi-8-appstream-rpms",
+          "referenceType": "purl",
+          "referenceCategory": "PACKAGE-MANAGER"
+        }
+      ],
+      "annotations": [
+        {
+          "annotator": "Tool: cachi2:jsonencoded",
+          "annotationDate": "2025-01-13T09:51:43Z",
+          "annotationType": "OTHER",
+          "comment": "{\"name\": \"cachi2:found_by\", \"value\": \"cachi2\"}"
+        }
+      ],
+      "downloadLocation": "NOASSERTION"
+    }
+  ],
+  "files": [],
+  "relationships": [
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-DocumentRoot-File-",
+      "relationshipType": "DESCRIBES"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-apr-util-bdb-1.6.1-80a350715c5d5bce1ed3adcb29bdac2f69b9e432b8e148486428fb5a1dbed133",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-apr-util-openssl-1.6.1-51b9c3b95c53f3b666732fc45eb7e926976375b5e848a0ff53c05e765441a319",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-apr-util-1.6.1-54dac25e7fe18cff27ca527e7bd31f72d11596f313c8997cc7f5eda57396d4e6",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-apr-util-1.6.1-158322a7f051adb5cbf6a7e1d5a06c716bbf00d2a11211a8410023c2fc7cf2d0",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-apr-1.6.3-1e2e21f55c49e50881b467a875d1bbfede39dfe02594958a02463f5dbdb6e05e",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-apr-1.6.3-f45835cfe760749f68574114b52bbfd25036acdd30ce3553c30a4708056dbbf2",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-httpd-tools-2.4.37-9635cd40e1b282eefd2d4dd96daf7b7d924041d526f0c7267f129a524a4894ac",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-httpd-2.4.37-4b5382e33a9ca75388ecf09694c83f42996d010c4ffb2bb68315fd79bf814406",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-glibc-common-2.39-d94aa3f6228e20ca5fc645a33339470bb020492c164adf965d69388fc85a6e92",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-glibc-common-2.39-fab6e099abf5033d3104beadf5ff1bf60708378f3a52f6e3d92ecdf708d3329a",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-glibc-minimal-langpack-2.38-3a5546b79055579930b001b0ff7d3aedf0cdce68ab86148169fa8d6f004ad7eb",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-glibc-minimal-langpack-2.39-e7fa29dee8fa39c1c698993c821122e82be41477d32b1e1927cc27005f92ec3f",
+      "relationshipType": "CONTAINS"
+    },
+    {
+      "spdxElementId": "SPDXRef-DocumentRoot-File-",
+      "comment": "",
+      "relatedSpdxElement": "SPDXRef-Package-gzip-1.13-9d35dafbe4dd02490cb1d8927e51b0e34f7da5d593a4f30570c1f0a435a0d2db",
+      "relationshipType": "CONTAINS"
+    }
+  ]
+}

--- a/scripts/icm-injection-scripts/test-inject-icm.sh
+++ b/scripts/icm-injection-scripts/test-inject-icm.sh
@@ -20,16 +20,16 @@ cleanup() {
 trap cleanup EXIT
 
 WORKDIR=$(mktemp -d --suffix=-icm-inject-test)
-
-banner "Creating test image: $TEST_IMAGE"
-test_container=$(buildah from registry.fedoraproject.org/fedora-minimal:41)
-buildah commit "$test_container" "$TEST_IMAGE"
+cp "$SCRIPTDIR/test-data/Containerfile" "$WORKDIR/Containerfile"
 
 cd "$WORKDIR"
 
 banner "Running inject-icm.sh with a $TEST_SBOM_FORMAT SBOM"
 cp "$SCRIPTDIR/test-data/sbom-cachi2-$TEST_SBOM_FORMAT.json" ./sbom-cachi2.json
-bash "$SCRIPTDIR/inject-icm.sh" "$TEST_IMAGE"
+bash "$SCRIPTDIR/inject-icm.sh" Containerfile
+
+banner "Creating test image: $TEST_IMAGE"
+buildah build Containerfile "$TEST_IMAGE"
 
 expect_icm=$(jq -n '{
   "metadata": {

--- a/scripts/icm-injection-scripts/test-inject-icm.sh
+++ b/scripts/icm-injection-scripts/test-inject-icm.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+
+: "${TEST_SBOM_FORMAT?must set variable; valid values: cyclonedx, spdx}"
+: "${TEST_IMAGE=icm-inject-test:latest}"
+
+banner() {
+    echo "--------------------------------------------------------------------------------"
+    echo "$1"
+    echo "--------------------------------------------------------------------------------"
+}
+
+cleanup() {
+    rm -r "$WORKDIR" || true
+    buildah rm "$test_container" >/dev/null || true
+    buildah rmi "$TEST_IMAGE" >/dev/null || true
+}
+trap cleanup EXIT
+
+WORKDIR=$(mktemp -d --suffix=-icm-inject-test)
+
+banner "Creating test image: $TEST_IMAGE"
+test_container=$(buildah from registry.fedoraproject.org/fedora-minimal:41)
+buildah commit "$test_container" "$TEST_IMAGE"
+
+cd "$WORKDIR"
+
+banner "Running inject-icm.sh with a $TEST_SBOM_FORMAT SBOM"
+cp "$SCRIPTDIR/test-data/sbom-cachi2-$TEST_SBOM_FORMAT.json" ./sbom-cachi2.json
+bash "$SCRIPTDIR/inject-icm.sh" "$TEST_IMAGE"
+
+expect_icm=$(jq -n '{
+  "metadata": {
+    "icm_version": 1,
+    "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+    "image_layer_index": 0
+  },
+  "from_dnf_hint": true,
+  "content_sets": [
+    "releases",
+    "ubi-8-appstream-rpms",
+    "ubi-8-appstream-source"
+  ]
+}')
+
+banner "Checking the content of /usr/share/buildinfo/content-sets.json in $TEST_IMAGE"
+
+got_icm=$(podman run --rm "$TEST_IMAGE" cat /usr/share/buildinfo/content-sets.json | jq)
+
+if [[ "$expect_icm" != "$got_icm" ]]; then
+    printf "%s\n" \
+        "❌ Mismatched ICM files!" \
+        "------------------------" \
+        "Expected:" \
+        "$expect_icm" \
+        "------------------------" \
+        "Got:" \
+        "$got_icm"
+    exit 1
+else
+    echo "✅ Success!"
+fi


### PR DESCRIPTION
In order to stop creating an additional layer with the content sets, we can add the content sets when building the original image. This requires the script to be available within the task image and modified from adding another commit to instead just appending the `COPY` command to the Containerfile.

This is an alternative approach to modifying the image content manifest script to be able to just verify that the content set is correct (https://github.com/konflux-ci/build-tasks-dockerfiles/pull/275).