### PR TITLE
Update dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "buildah"]
 	path = buildah
 	url = https://github.com/containers/buildah.git
+	branch = main
 [submodule "image_build"]
 	path = image_build
 	url = https://github.com/containers/image_build.git

--- a/Containerfile.image_build
+++ b/Containerfile.image_build
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:40 as builder
+FROM registry.fedoraproject.org/fedora-minimal:41 as builder
 
 ARG BUILDER_RPMS="make golang glib2-devel gpgme-devel libassuan-devel libseccomp-devel git bzip2 runc containers-common"
 RUN microdnf -y install $BUILDER_RPMS
@@ -25,12 +25,22 @@ RUN make buildah
 # that runs safely with privileges within the container.
 #
 
-FROM registry.fedoraproject.org/fedora-minimal:40
+FROM registry.fedoraproject.org/fedora-minimal:41
 
 LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
-LABEL name="buildah" \
-      summary="Containerized version of buildah which can be used to build OCI artifacts" \
-      com.redhat.component="konflux-ci-buildah" \
+LABEL \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vendor="Konflux CI" \
+      org.opencontainers.image.vendor="Konflux CI" \
+      org.opencontainers.image.url="https://quay.io/konflux-ci/buildah" \
+      org.opencontainers.image.source="https://github.com/konflux-ci/buildah-container" \
+      org.label-schema.name="buildah" \
+      org.opencontainers.image.title="buildah" \
+      name="konflux-buildah" \
+      com.redhat.component="konflux-buildah" \
+      io.k8s.display-name="konflux-buildah" \
+      io.openshift.tags="buildah oci" \
+      summary="Containerized version of buildah which can be used to build OCI artifacts within Konflux CI." \
       description="OCI images and artifacts are central to the architecture of Konflux. In order to ensure that we can always take advantage of the latest functionality, this image can be used to reliably build the latest version of the CLI." \
       io.k8s.display-name="buildah" \
       io.k8s.description="OCI images and artifacts are central to the architecture of Konflux. In order to ensure that we can always take advantage of the latest functionality, this image can be used to reliably build the latest version of the CLI." \

--- a/Containerfile.task
+++ b/Containerfile.task
@@ -5,7 +5,7 @@
 # for our tasks that has more than _just_ buildah in it. We also need to add the required functionality
 # for the remote builds.
 
-FROM registry.fedoraproject.org/fedora-minimal:40 AS dockerfile-json-builder
+FROM registry.fedoraproject.org/fedora-minimal:41 AS dockerfile-json-builder
 
 ARG BUILDER_RPMS="golang"
 RUN microdnf install -y $BUILDER_RPMS
@@ -20,6 +20,18 @@ RUN go build -o dockerfile-json
 COPY scripts/icm-injection-scripts/inject-icm.sh /scripts
 
 FROM quay.io/redhat-user-workloads/rhtap-build-tenant/buildah-container/buildah@sha256:391ce6bd8652a81d1237d4aec46acabec0a6b61f9a7ea94a16ffa1a40d759378
+
+LABEL \
+    org.opencontainers.image.url="https://quay.io/konflux-ci/buildah-task" \
+    org.label-schema.name="buildah-task" \
+    org.opencontainers.image.title="buildah-task" \
+    name="konflux-buildah-task" \
+    com.redhat.component="konflux-buildah-task" \
+    io.k8s.display-name="konflux-buildah-task" \
+    io.openshift.tags="buildah tekton" \
+    summary="Command line tool to create and work with containers within Tekton tasks." \
+    description="Command line tool to create and work with containers. This is a repackaged version for use within Tekton tasks in Konflux CI. It includes additional functionality on top of buildah that might be required for the tasks." \
+    io.k8s.description="Command line tool to create and work with containers. This is a repackaged version for use within Tekton tasks in Konflux CI. It includes additional functionality on top of buildah that might be required for the tasks."
 
 ARG INSTALL_RPMS="rsync openssh-clients kubernetes-client jq iproute subscription-manager"
 RUN microdnf install -y $INSTALL_RPMS && \


### PR DESCRIPTION
This includes:
* Fedora
* buildah

I considered moving to registry.access.redhat.com/ubi9/ubi-minimal as that has go 1.23 support but the version of unshare is still too old. We need to stay with Fedora parent images a little longer.