### PR TITLE
Parameterize the icm injection script inputs and outputs

### DIFF
--- a/scripts/icm-injection-scripts/test-inject-icm.sh
+++ b/scripts/icm-injection-scripts/test-inject-icm.sh
@@ -25,7 +25,7 @@ cd "$WORKDIR"
 
 banner "Running inject-icm.sh with a $TEST_SBOM_FORMAT SBOM"
 cp "$SCRIPTDIR/test-data/sbom-cachi2-$TEST_SBOM_FORMAT.json" ./sbom-cachi2.json
-bash "$SCRIPTDIR/inject-icm.sh" Containerfile
+bash "$SCRIPTDIR/inject-icm.sh" Containerfile ./sbom-cachi2.json
 
 banner "Creating test image: $TEST_IMAGE"
 buildah build -f Containerfile -t "$TEST_IMAGE"


### PR DESCRIPTION
The second parameter is the location of the prefetch SBOM

Since we need to inject the content sets into the Containerfile with an
additional COPY command, we don't want to require that the sbom is in
the current directory in case that pollutes the container image's build
context. Instead, we parameterize it as the location may vary between
applications of this script.

The third parameter is the output directory

Since we need to be able to copy content-sets.json into the image, we
have to ensure that the file is present within the build's context. The
output directory should be set to that location.