### PR TITLE
feat: reduce unnecessary push builds

### DIFF
--- a/.tekton/buildah-push.yaml
+++ b/.tekton/buildah-push.yaml
@@ -7,10 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
-      (".tekton/build-pipeline.yaml".pathChanged() ||
-      ".tekton/buildah-pull-request.yaml".pathChanged() ||
-      ".tekton/buildah-push.yaml".pathChanged() ||
-      "buildah".pathChanged() ||
+      ("buildah".pathChanged() ||
       "image_build".pathChanged() ||
       "Containerfile.image_build".pathChanged())
   creationTimestamp: null

--- a/.tekton/buildah-task-push.yaml
+++ b/.tekton/buildah-task-push.yaml
@@ -7,10 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
-      (".tekton/build-pipeline.yaml".pathChanged() ||
-      ".tekton/buildah-task-pull-request.yaml".pathChanged() ||
-      ".tekton/buildah-task-push.yaml".pathChanged() ||
-      "dockerfile-json".pathChanged() ||
+      ("dockerfile-json".pathChanged() ||
       "Containerfile.task".pathChanged() ||
       "scripts/**".pathChanged())
   creationTimestamp: null

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 This is a rebuild of [containers/buildah](https://github.com/containers/buildah) for use in Konflux-CI. Two images are produced by this repository. One is a simple rebuild of `buildah` and is available at [quay.io/konflux-ci/buildah:latest](https://quay.io/konflux-ci/buildah). The other is oriented at customizing the behavior of `buildah` within Tekton tasks and is available at [quay.io/konflux-ci/buildah-task:latest](https://quay.io/konflux-ci/buildah-task).
 
+## Building artifacts
+
+By default, new artifacts will not be built when only the contents of the `.tekton` have changed for push events. These changes will
+still be tested for pull request events. If you want to trigger a rebuild of an artifact for push events, you can manually trigger one
+as mentioned in the [Konflux documentation](https://konflux-ci.dev/docs/building/rerunning/).
+
+To see when new builds will be triggered for push events, you can look at the `pipelinesascode.tekton.dev/on-cel-expression` annotation
+for the specific components. For example, the `buildah-task` component will only be built if there are changes to its Containerfile or
+either of the dependencies mentioned.
+
+```yaml
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main" &&
+      ("dockerfile-json".pathChanged() ||
+      "Containerfile.task".pathChanged() ||
+      "scripts/**".pathChanged())
+```
+
 ## Updating the git submodule
 
 ```bash


### PR DESCRIPTION
We do not need to rebuild the buildah images if the only changes are to the Tekton pipelines. These changes will automatically be picked up once we have substantive changes that are pushed to the images.

By not rebuilding on these changes, we can more easily enable an auto-release flow that does not result in the potential follow-on updates to the buildah-related tasks.