### PR TITLE
Use buildah v1.40.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,9 @@
 [submodule "buildah"]
 	path = buildah
 	url = https://github.com/containers/buildah.git
-	branch = main
+	# https://docs.renovatebot.com/modules/manager/git-submodules/#updating-to-specific-tag-values
+	# Note: breaks 'git submodule update --remote'. See the doc ^
+	branch = v1.40.1
 [submodule "image_build"]
 	path = image_build
 	url = https://github.com/containers/image_build.git


### PR DESCRIPTION
Previously, we were at some commit between v1.40.1 and v1.41.0.

Between those commits, buildah changed the layout of hardlinks in
layers. Most notably, this affects images installing a specific version
of the git RPM which creates ~100 hardlinks to /usr/bin/git. Syft is
unable to process those images, failing with "maximum link resolution
stack depth exceeded".

See the upstream issue [1] for more details.

Revert to v1.40.1 until the issue is resolved upstream.

Also configure renovate to track releases instead of main.

[1]: https://github.com/containers/buildah/issues/6297