### PR TITLE
fix(icm): keep ICM on the old location too

### DIFF
--- a/scripts/icm-injection-scripts/test-inject-icm.sh
+++ b/scripts/icm-injection-scripts/test-inject-icm.sh
@@ -25,7 +25,7 @@ cd "$WORKDIR"
 
 banner "Running inject-icm.sh with a $TEST_SBOM_FORMAT SBOM"
 cp "$SCRIPTDIR/test-data/sbom-cachi2-$TEST_SBOM_FORMAT.json" ./sbom-cachi2.json
-bash "$SCRIPTDIR/inject-icm.sh" Containerfile ./sbom-cachi2.json
+bash "$SCRIPTDIR/inject-icm.sh" -c Containerfile ./sbom-cachi2.json
 
 banner "Creating test image: $TEST_IMAGE"
 buildah build -f Containerfile -t "$TEST_IMAGE"
@@ -57,6 +57,24 @@ if [[ "$expect_icm" != "$got_icm" ]]; then
         "------------------------" \
         "Got:" \
         "$got_icm"
+    exit 1
+else
+    echo "✅ Success!"
+fi
+
+banner "Checking the content of /root/buildinfo/content_manifests/content-sets.json in $TEST_IMAGE (backward compatibility)"
+
+got_icm_compat=$(podman run --rm "$TEST_IMAGE" cat /root/buildinfo/content_manifests/content-sets.json | jq)
+
+if [[ "$expect_icm" != "$got_icm_compat" ]]; then
+    printf "%s\n" \
+        "❌ Mismatched ICM files!" \
+        "------------------------" \
+        "Expected:" \
+        "$expect_icm" \
+        "------------------------" \
+        "Got:" \
+        "$got_icm_compat"
     exit 1
 else
     echo "✅ Success!"


### PR DESCRIPTION
In https://github.com/konflux-ci/build-tasks-dockerfiles/pull/243/files was chaged path where ICM is stored in the container (old repo, since that the script was migrated to new repo). However this breaks compatibility with other scanners than Clair. We must keep both locations for now and start long term deprecation process