### PR TITLE
Migrate buildah images to UBI10 base image

### DIFF
--- a/Containerfile.buildah
+++ b/Containerfile.buildah
@@ -1,8 +1,8 @@
 # Source from buildah/contrib/docker/Dockerfile
-FROM Fedora
+FROM registry.access.redhat.com/ubi10/ubi@sha256:b51579c045599bc2f2ba407f28fcc26e13b87409e062e227b185ae69d699bf95
 RUN dnf -y update && dnf -y clean all
-RUN dnf -y install btrfs-progs-devel containers-common golang go-md2man gpgme-devel libassuan-devel libseccomp-devel make net-tools runc shadow-utils glibc-static libselinux-static libseccomp-static && dnf -y clean all
-COPY . /go/src/github.com/containers/buildah
+RUN dnf -y install containers-common golang gpgme-devel libassuan-devel libseccomp-devel make net-tools shadow-utils glibc-static && dnf -y clean all
+COPY buildah/ /go/src/github.com/containers/buildah
 RUN env GOPATH=/go make -C /go/src/github.com/containers/buildah clean all install
 RUN sed -i -r -e 's,driver = ".*",driver = "vfs",g' /etc/containers/storage.conf
 ENV BUILDAH_ISOLATION chroot

--- a/Containerfile.image_build
+++ b/Containerfile.image_build
@@ -1,6 +1,6 @@
-FROM registry.fedoraproject.org/fedora-minimal:41 as builder
+FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:5a57b4c2509df8df587e19cc7c2d9cfa45b012139f5decd77f942daeb2334228 as builder
 
-ARG BUILDER_RPMS="make golang glib2-devel gpgme-devel libassuan-devel libseccomp-devel git bzip2 runc containers-common"
+ARG BUILDER_RPMS="make golang glib2-devel gpgme-devel libassuan-devel libseccomp-devel git bzip2 containers-common"
 RUN microdnf -y install $BUILDER_RPMS
 
 ENV GOPROXY='https://proxy.golang.org,direct'
@@ -25,7 +25,7 @@ RUN make buildah
 # that runs safely with privileges within the container.
 #
 
-FROM registry.fedoraproject.org/fedora-minimal:41
+FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:5a57b4c2509df8df587e19cc7c2d9cfa45b012139f5decd77f942daeb2334228
 
 LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
 LABEL \
@@ -50,20 +50,16 @@ LABEL \
       release="0" \
       url="github.com/konflux-ci/buildah-container"
 
-ARG INSTALL_RPMS="buildah fuse-overlayfs ucpp"
+ARG INSTALL_RPMS="buildah fuse-overlayfs cpp"
 
 # Don't include container-selinux and remove
 # directories used by dnf that are just taking
 # up space.
-# TODO: rpm --setcaps... needed due to Fedora (base) image builds
-#       being (maybe still?) affected by
-#       https://bugzilla.redhat.com/show_bug.cgi?id=1995337#c3
-RUN microdnf -y makecache && \
+RUN printf "[main]\nexcludepkgs=container-selinux" > /etc/dnf/dnf.conf && \
+    microdnf -y makecache && \
     microdnf -y update && \
     microdnf -y install shadow-utils && \
-    rpm --setcaps shadow-utils 2>/dev/null && \
-    microdnf -y install $INSTALL_RPMS --exclude container-selinux && \
-    ln -s /usr/bin/ucpp /usr/local/bin/cpp && \
+    microdnf -y install $INSTALL_RPMS && \
     microdnf -y clean all && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 


### PR DESCRIPTION
The buildah-container images currently use Fedora as a base image.
There was an issue with the `unshare` version in UBI versions <10, that
is now fixed.

UBI does not contain all packages that Fedora does in its repositories,
but they should not be necessary.

Notes for reviewers:
The buildah task using UBI10 has been tested in https://github.com/tnevrlka-test/devfile-sample-hello-world-test/pull/14