### PR TITLE
Update UBI base image

### DIFF
--- a/Containerfile.image_build
+++ b/Containerfile.image_build
@@ -11,7 +11,7 @@ COPY buildah/ .
 RUN make buildah
 
 # buildah/Containerfile
-# 
+#
 # Source from the included submodule at
 # image_build/blob/main/buildah/Containerfile.
 # We will install buildah as an RPM to ensure that we have
@@ -25,7 +25,7 @@ RUN make buildah
 # that runs safely with privileges within the container.
 #
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:d8cba62fbd44610595a6ce7badd287ca4c9985cbe9df55cc9b6a5c311b9a46e6
+FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:53de6ac7c3e830b0ddfc9867ff6a8092785bcf156ab4e63dfa9af83c880fd988
 
 LABEL "io.containers.capabilities"="CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,NET_BIND_SERVICE,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT"
 LABEL \

--- a/Containerfile.task
+++ b/Containerfile.task
@@ -5,7 +5,7 @@
 # for our tasks that has more than _just_ buildah in it. We also need to add the required functionality
 # for the remote builds.
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:d8cba62fbd44610595a6ce7badd287ca4c9985cbe9df55cc9b6a5c311b9a46e6 AS dep-builder
+FROM registry.access.redhat.com/ubi10/ubi-minimal@sha256:53de6ac7c3e830b0ddfc9867ff6a8092785bcf156ab4e63dfa9af83c880fd988 AS dep-builder
 
 ARG BUILDER_RPMS="golang make rsync"
 RUN microdnf install -y $BUILDER_RPMS


### PR DESCRIPTION
Conforma fails with:
```
Mismatched versions of the "python3-dnf" RPM were found across different arches. Platform linux/ppc64le has
python3-dnf-4.20.0-14.el10_0. Platforms linux/arm64, linux/s390x, linux/x86_64 have python3-dnf-4.20.0-12.el10_0.
```
Maybe updating base image can help.